### PR TITLE
Add fmt release 4.1.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,6 @@
+project('fmt', 'cpp', version : '4.1.0', license: 'BSD', default_options : ['cpp_std=c++14'])
+
+inc = include_directories('.')
+lib = library('fmt', ['fmt/format.cc', 'fmt/ostream.cc', 'fmt/printf.cc'])
+
+fmt_dep = declare_dependency(include_directories : inc, link_with : lib)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = fmt-4.1.0
+
+source_url = https://github.com/fmtlib/fmt/archive/4.1.0.tar.gz
+source_filename = fmt-4.1.0.tar.gz
+source_hash = 46628a2f068d0e33c716be0ed9dcae4370242df135aed663a180b9fd8e36733d


### PR DESCRIPTION
Not sure about `source_filename`, but when I downloaded the file with Firefox, it was named this way.