### PR TITLE
5.2.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,6 @@
+project('fmt', 'cpp', version : '5.2.1', license: 'BSD', default_options : ['cpp_std=c++14'])
+
+inc = include_directories('include')
+lib = library('fmt', ['src/format.cc', 'src/posix.cc'], include_directories : inc)
+
+fmt_dep = declare_dependency(include_directories : inc, link_with : lib)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = fmt-5.2.1
+
+source_url = https://github.com/fmtlib/fmt/archive/5.2.1.tar.gz
+source_filename = fmt-5.2.1.tar.gz
+source_hash = 3c812a18e9f72a88631ab4732a97ce9ef5bcbefb3235e9fd465f059ba204359b


### PR DESCRIPTION
Tested locally with a custom `fmt.wrap`.