### PR TITLE
Fix shared library symbol visibility on Windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,3 +27,8 @@ fmt_dep = declare_dependency(
     compile_args : fmt_interface_cpp_args,
     link_with : fmt_lib
 )
+
+fmt_header_only_dep = declare_dependency(
+    include_directories : fmt_inc,
+    compile_args : '-DFMT_HEADER_ONLY'
+)

--- a/meson.build
+++ b/meson.build
@@ -12,11 +12,6 @@ if libtype == 'shared'
     fmt_interface_cpp_args += [ '-DFMT_SHARED' ]
 endif
 
-if get_option('fmt_header_only')
-    add_project_arguments('-DFMT_HEADER_ONLY')
-endif
-
-
 fmt_inc = include_directories('include')
 fmt_lib = library('fmt',
     sources : [

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,34 @@
-project('fmt', 'cpp', version : '6.2.0', license: 'BSD', default_options : ['cpp_std=c++14'])
+project('fmt', 'cpp',
+    version : '6.2.0',
+    license : 'BSD',
+    default_options : ['cpp_std=c++14']
+)
 
-inc = include_directories('include')
-lib = library('fmt', ['src/format.cc', 'src/os.cc'], include_directories : inc)
+fmt_private_cpp_args = [ ]
+fmt_interface_cpp_args = [ ]
+libtype = get_option('default_library')
+if libtype == 'shared'
+    fmt_private_cpp_args += [ '-DFMT_EXPORT' ]
+    fmt_interface_cpp_args += [ '-DFMT_SHARED' ]
+endif
 
-fmt_dep = declare_dependency(include_directories : inc, link_with : lib)
+if get_option('fmt_header_only')
+    add_project_arguments('-DFMT_HEADER_ONLY')
+endif
+
+
+fmt_inc = include_directories('include')
+fmt_lib = library('fmt',
+    sources : [
+        'src/format.cc',
+        'src/os.cc'
+    ],
+    cpp_args : fmt_private_cpp_args,
+    include_directories : fmt_inc
+)
+
+fmt_dep = declare_dependency(
+    include_directories : fmt_inc,
+    compile_args : fmt_interface_cpp_args,
+    link_with : fmt_lib
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('fmt_header_only', type : 'boolean', value : false, description : 'Use fmt as header-only library' )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,0 @@
-option('fmt_header_only', type : 'boolean', value : false, description : 'Use fmt as header-only library' )


### PR DESCRIPTION
On Windows fmt was built as shared library but without setting necessary defines for making symbols usable.